### PR TITLE
Speedup settings for CI server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ php:
     - 7.0
 
 before_script:
-    - composer self-update
-    - composer install --no-interaction --dev --prefer-source
+    - composer install --no-interaction --prefer-source
 
 script: vendor/bin/tester -p php -s tests
 


### PR DESCRIPTION
-  update Composer is not necessary in CI server
- --dev is default configuration in Composer
